### PR TITLE
fix: Use alternate link Zotero (`https://www.zotero.org/username/item…

### DIFF
--- a/zotero2readwise/zotero.py
+++ b/zotero2readwise/zotero.py
@@ -178,7 +178,7 @@ class ZoteroAnnotationsNotes:
             item_type=item_type,
             text=text,
             annotated_at=data["dateModified"],
-            annotation_url=annot["links"]["self"]["href"],
+            annotation_url=annot["links"]["alternate"]["href"],
             comment=comment,
             title=metadata["title"],
             tags=data["tags"],


### PR DESCRIPTION
…s/<itemKey>`) that has a html content instead of self link (`https://api.zotero.org/users/<userID>/items/<itemKey>`) that contains a JSON content and calls the API.