### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: If you do not have pip installed on your system, you can follow the instru
 # Usage
 Since we have to retrieve the notes from Zotero API and then upload them to the Readwise, the minimum requirements are:
 * **Readwise access token** [Required]: You can get your access token from https://readwise.io/access_token
-* **Zotero API key** [Required]: Create a new Zotero Key from [your Zotero settings](https://www.zotero.org/settings/key)
+* **Zotero API key** [Required]: Create a new Zotero Key from [your Zotero settings](https://www.zotero.org/settings/keys/new)
 * **Zotero personal or group ID** [Required]: 
     * Your **personal library ID** (aka **userID**) can be found [here](https://www.zotero.org/settings/key) next to `Your userID for use in API calls is XXXXXX`.
     * If you're using a **group library**, you can find the library ID by 


### PR DESCRIPTION
Link to Zotero Settings changed from https://www.zotero.org/settings/key to https://www.zotero.org/settings/keys

I also added /new to directly link to generating a new key, maybe you could explain which settings are needed for a new key (read/write).