### PR TITLE
nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you have `nix`, you can skip any installation and do:
 nix run github:e-alizadeh/Zotero2Readwise -- <readwise_token> <zotero_key> <zotero_id>
 ```
 The text file with failed highlights, which usually would be written to the Zotero2Readwise python package directory, will now be written to you working directory, since nix does not allow writing to package directories.
+If you don't want this file created, supply `--suppress_failures` as an additional argument.
 
 ---
 # [Zotero2Readwise-Sync](https://github.com/e-alizadeh/Zotero2Readwise-Sync)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ item key will be saved to a txt file.
 ```python
 zt_rw.readwise.save_failed_items_to_json("failed_readwise_highlights.json")
 ```
+
+## Approach 3 (through the nix flake)
+If you have `nix`, you can skip any installation and do:
+```sh
+nix run github:e-alizadeh/Zotero2Readwise -- <readwise_token> <zotero_key> <zotero_id>
+```
+The text file with failed highlights, which usually would be written to the Zotero2Readwise python package directory, will now be written to you working directory, since nix does not allow writing to package directories.
+
 ---
 # [Zotero2Readwise-Sync](https://github.com/e-alizadeh/Zotero2Readwise-Sync)
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,155 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720066371,
+        "narHash": "sha256-uPlLYH2S0ACj0IcgaK9Lsf4spmJoGejR9DotXiXSBZQ=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "622f829f5fe69310a866c8a6cd07e747c44ef820",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728018373,
+        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1728228884,
+        "narHash": "sha256-E9JaDKGi21oUypH0P9881lbkhi6USNJ6XL2tFzU5uuE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ff0da78cfd41aa1784910ce1fea89119822013ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": "nixpkgs_2",
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1728266256,
+        "narHash": "sha256-RefXB9kqYch6uGT+mo6m3KTbNerfbDYz+EqkLb6YBbs=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "8e965fd42c0da4357c53d987bc62b54a954424da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1727984844,
+        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,33 +1,30 @@
 {
   description = "Nix flake for running zotero2readwise script";
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
-    flake-parts.url = "github:hercules-ci/flake-parts";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.poetry2nix.url = "github:nix-community/poetry2nix";
 
-  outputs = { self, nixpkgs, flake-parts }:
-    flake-parts.lib.mkFlake { systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]; } {
-      perSystem = { system, pkgs, ... }: {
-        packages.default = pkgs.python3Packages.buildPythonPackage {
-          pname = "zotero2readwise-runner";
-          version = "0.1.0";
-
-          src = ./.;
-
-          buildInputs = [
-            pkgs.python3Packages.pip
-          ];
-
-          propagatedBuildInputs = [];
-
-          doInstallCheck = false;
-          meta.license = pkgs.lib.licenses.mit;
-        };
-
-        apps.default = {
-          type = "app";
-          program = "${self.packages.${flake-parts.lib.systemToPackagesKey system}.default}/bin/python3 ${self.packages.${flake-parts.lib.systemToPackagesKey system}.default}/run.py";
-        };
+  outputs = { self, nixpkgs, poetry2nix }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      inherit (poetry2nix.lib.mkPoetry2Nix { inherit pkgs; }) mkPoetryApplication defaultPoetryOverrides;
+      zotero2readwise = mkPoetryApplication {
+        projectDir = ./.;
+        # Pyzotero requires setuptools.
+        # https://github.com/nix-community/poetry2nix/blob/master/docs/edgecases.md
+        overrides = defaultPoetryOverrides.extend (final: prev: {
+          pyzotero = prev.pyzotero.overridePythonAttrs ( old: {
+            buildInputs = (old.buildInputs or [ ]) ++ [ prev.setuptools ];
+          });
+        });
+      };
+    in
+    {
+      apps.${system}.default = {
+        type = "app";
+        # replace <script> with the name in the [tool.poetry.scripts] section of your pyproject.toml
+        program = "${zotero2readwise}/bin/run";
       };
     };
 }
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Nix flake for running zotero2readwise script";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = { self, nixpkgs, flake-parts }:
+    flake-parts.lib.mkFlake { systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]; } {
+      perSystem = { system, pkgs, ... }: {
+        packages.default = pkgs.python3Packages.buildPythonPackage {
+          pname = "zotero2readwise-runner";
+          version = "0.1.0";
+
+          src = ./.;
+
+          buildInputs = [
+            pkgs.python3Packages.pip
+          ];
+
+          propagatedBuildInputs = [];
+
+          doInstallCheck = false;
+          meta.license = pkgs.lib.licenses.mit;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${flake-parts.lib.systemToPackagesKey system}.default}/bin/python3 ${self.packages.${flake-parts.lib.systemToPackagesKey system}.default}/run.py";
+        };
+      };
+    };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,15 @@ env = "GH_TOKEN" # default env name containing the GitHub Token
 python = "^3.8"
 Pyzotero = "^1.4.26"
 requests = "^2.26.0"
+setuptools = ">= 45"  # necessary for python 3.12
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^7.32.0"
 pre-commit = "^2.16.0"
 ipdb = "^0.13.9"
+
+[tool.poetry.scripts]
+run = "zotero2readwise.run:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/zotero2readwise/__init__.py
+++ b/zotero2readwise/__init__.py
@@ -1,7 +1,10 @@
+import os
 from pathlib import Path
 
 __author__ = "Essi Alizadeh"
 __version__ = "0.4.5"
 
 TOP_DIR = Path(__file__).parent
-FAILED_ITEMS_DIR = TOP_DIR
+# If TOP_DIR is readonly os with nix,
+# then failed_zotero_items.json is written to the working directory instead.
+FAILED_ITEMS_DIR = TOP_DIR if os.access(TOP_DIR, os.W_OK) else Path(".")

--- a/zotero2readwise/__init__.py
+++ b/zotero2readwise/__init__.py
@@ -7,4 +7,5 @@ __version__ = "0.4.5"
 TOP_DIR = Path(__file__).parent
 # If TOP_DIR is readonly os with nix,
 # then failed_zotero_items.json is written to the working directory instead.
-FAILED_ITEMS_DIR = TOP_DIR if os.access(TOP_DIR, os.W_OK) else Path(".")
+FAILED_ITEMS_DIR = TOP_DIR if os.access(TOP_DIR, os.W_OK) else Path.cwd()
+print(TOP_DIR, FAILED_ITEMS_DIR, sep="\n")

--- a/zotero2readwise/__init__.py
+++ b/zotero2readwise/__init__.py
@@ -8,4 +8,3 @@ TOP_DIR = Path(__file__).parent
 # If TOP_DIR is readonly os with nix,
 # then failed_zotero_items.json is written to the working directory instead.
 FAILED_ITEMS_DIR = TOP_DIR if os.access(TOP_DIR, os.W_OK) else Path.cwd()
-print(TOP_DIR, FAILED_ITEMS_DIR, sep="\n")

--- a/zotero2readwise/run.py
+++ b/zotero2readwise/run.py
@@ -47,6 +47,11 @@ def main():
         action='store_true',
         help="Include Zotero items since last run"
     )
+    parser.add_argument(
+        "--suppress_failures",
+        action='store_true',
+        help="Do not write annotations that failed to port to a report file."
+    )
 
     args = vars(parser.parse_args())
 
@@ -68,7 +73,8 @@ def main():
         include_annotations=args["include_annotations"],
         include_notes=args["include_notes"],
         filter_colors=args["filter_color"],
-        since=since
+        since=since,
+        write_failures=not args["suppress_failures"]
     )
     zt2rw.run()
     if args["use_since"]:

--- a/zotero2readwise/run.py
+++ b/zotero2readwise/run.py
@@ -5,7 +5,7 @@ from zotero2readwise.helper import write_library_version, read_library_version
 from zotero2readwise.zt2rw import Zotero2Readwise
 
 
-if __name__ == "__main__":
+def main():
     parser = ArgumentParser(description="Generate Markdown files")
     parser.add_argument(
         "readwise_token",
@@ -73,3 +73,6 @@ if __name__ == "__main__":
     zt2rw.run()
     if args["use_since"]:
         write_library_version(zt2rw.zotero_client)
+
+if __name__ == "__main__":
+    main()

--- a/zotero2readwise/zt2rw.py
+++ b/zotero2readwise/zt2rw.py
@@ -17,7 +17,8 @@ class Zotero2Readwise:
         include_annotations: bool = True,
         include_notes: bool = False,
         filter_colors: List[str] = [],
-        since: int = 0
+        since: int = 0,
+        write_failures: bool = True
     ):
         self.readwise = Readwise(readwise_token)
         self.zotero_client = get_zotero_client(
@@ -29,6 +30,7 @@ class Zotero2Readwise:
         self.include_annots = include_annotations
         self.include_notes = include_notes
         self.since = since
+        self.write_failures = write_failures
 
     def get_all_zotero_items(self) -> List[Dict]:
             """
@@ -54,7 +56,7 @@ class Zotero2Readwise:
 
         formatted_items = self.zotero.format_items(zot_annots_notes)
 
-        if self.zotero.failed_items:
+        if self.write_failures and self.zotero.failed_items:
             self.zotero.save_failed_items_to_json("failed_zotero_items.json")
 
         self.readwise.post_zotero_annotations_to_readwise(formatted_items)


### PR DESCRIPTION
This pull request adds an additional way of calling Zotero2Readwise, but with no manual user installation required if they use nix.
You can already test it out with `nix run github:jjjholscher/zotero2readwise`.
The flake is made such that I don't expect it to require maintenance, since it uses `poetry.lock` to look up dependencies.

I'll explain the edits:

**pyproject.toml**  
You use distutils, which as of python 3.12 is no longer included in the standard library, you need to include `setuptools` manually in the pyproject.toml if you want to continue relying on it.
I picked the version to match that of [pyzotero](https://github.com/urschrei/pyzotero/blob/master/pyproject.toml), which seems to work.

For nix to recognize `run.py` as an entrypoint for the code, I had to add it under `[tool.poetry.scripts]`. I think this is general good practice, now poetry will recognize it and you can call it with `poetry run run`. (yes, that might be a bit confusing, I wasn't sure whether to name it zotero2readwise or main instead, such that you'd get `poetry run zotero2readwise` or `poetry run main`)

**__init__.py**
Your code always writes an error file to the package directory.
That's not possible in nix, so I had to include a check whether that users has write permissions there.
If not, the error file will be written to the working directory.

**run.py** and **zt2rw.py**
I assume not everyone will be glad that a `nix run github:jjjholscher/zotero2readwise` call will write a file to their working directory so I added a cli flag and a check to give the user the option for that not to happen in 102a46d10ef58205a7f885769f9326fa995dce8c
If you don't like that, you can go to 102a46d10ef58205a7f885769f9326fa995dce8c instead, which is a working version of this PR without that flag (don't mind the fact that the next commit mentions debugging, I merely neglected to refresh the flake.nix on my end, there was nothing wrong with the code)

### maintenance burden

I don't expect there to be any for the next year, possibly there will literally never be any, especially if you don't change or update the code much.
Here are the two main scenarios where I envision scenarios where something should be manually updated:

If you ever choose to stop relying on `run.py` for the CLI entry, then the `[tools.poetry.scripts]` section in the `pyproject.toml` should reflect that.

If you ever update your dependencies _and_ the dependencies use a _new_ build system, the flake _might_ complain about that. This should be very rare and be easily fixable. If you are curious you can see that I had to add
```
        overrides = defaultPoetryOverrides.extend (final: prev: {
          pyzotero = prev.pyzotero.overridePythonAttrs ( old: {
            buildInputs = (old.buildInputs or [ ]) ++ [ prev.setuptools ];
          });
        });
```
to the flake, which is how such problems tend to be resolvable. Feel free to contact me if this happens and you don't want to burden yourself with that (I don't expect it to happen).

### should you trust me?

I don't have much experience writing nix flakes.
Overal flakes are made to require little maintenance, and have no changing behavior if the lock files remain the same.
People can even invoke past versions of flakes, by supplying a git commit, in case HEAD stops working.
But, I understand if you don't want to include technology in your git repo that you yourself don't understand (if that's the case), in which case I'll just keep my fork alive (and maybe you could mention its existence in the readme, such that nix users know they might be able to use it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new usage approach for the `zotero2readwise` library using Nix, allowing users to run the library without installation.
	- Added a command-line option to suppress the creation of a report file for failed highlights.
	- Updated the `run` script to encapsulate logic in a `main()` function and added an option to suppress writing failed annotations.

- **Bug Fixes**
	- Enhanced logic to determine the directory for storing failed Zotero items based on write permissions.

- **Documentation**
	- Updated `README.md` to include new usage instructions and command format for the Nix approach.

- **Chores**
	- Updated project version and added necessary dependencies in `pyproject.toml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->