### PR TITLE
Fix: restore compatibility with pyzotero >=1.5 and Zotero API

### DIFF
--- a/zotero2readwise/zotero.py
+++ b/zotero2readwise/zotero.py
@@ -4,7 +4,8 @@ from os import environ
 from typing import Dict, List, Optional
 
 from pyzotero.zotero import Zotero
-from pyzotero.zotero_errors import ParamNotPassed, UnsupportedParams
+from pyzotero.zotero_errors import UnsupportedParams
+ParamNotPassed = UnsupportedParams
 
 from zotero2readwise import FAILED_ITEMS_DIR
 

--- a/zotero2readwise/zotero.py
+++ b/zotero2readwise/zotero.py
@@ -4,8 +4,6 @@ from os import environ
 from typing import Dict, List, Optional
 
 from pyzotero.zotero import Zotero
-from pyzotero.zotero_errors import UnsupportedParams
-ParamNotPassed = UnsupportedParams
 
 from zotero2readwise import FAILED_ITEMS_DIR
 
@@ -87,7 +85,7 @@ def get_zotero_client(
         try:
             library_id = environ["ZOTERO_LIBRARY_ID"]
         except KeyError:
-            raise ParamNotPassed(
+            raise ValueError(
                 "No value for library_id is found. "
                 "You can set it as an environment variable `ZOTERO_LIBRARY_ID` or use `library_id` to set it."
             )
@@ -96,7 +94,7 @@ def get_zotero_client(
         try:
             api_key = environ["ZOTERO_KEY"]
         except KeyError:
-            raise ParamNotPassed(
+            raise ValueError(
                 "No value for api_key is found. "
                 "You can set it as an environment variable `ZOTERO_KEY` or use `api_key` to set it."
             )
@@ -104,7 +102,7 @@ def get_zotero_client(
     if library_type is None:
         library_type = environ.get("LIBRARY_TYPE", "user")
     elif library_type not in ["user", "group"]:
-        raise UnsupportedParams("library_type value can either be 'user' or 'group'.")
+        raise ValueError("library_type value can either be 'user' or 'group'.")
 
     return Zotero(
         library_id=library_id,

--- a/zotero2readwise/zt2rw.py
+++ b/zotero2readwise/zt2rw.py
@@ -79,5 +79,5 @@ class Zotero2Readwise:
             print(f"Retrieving {item_type}s since last run from Zotero Database")
 
         print("It may take some time...")
-        query = self.zotero_client.items(itemType={item_type}, since=since)
+        query = self.zotero_client.items(itemType=item_type, since=since)
         return self.zotero_client.everything(query)


### PR DESCRIPTION
### Summary

Fixes compatibility with latest `pyzotero` versions by:

- Removing deprecated exception imports (`ParamNotPassed`, `UnsupportedParams`)
- Replacing with standard `ValueError`
- Fixing invalid `itemType` API call (was previously passed as a `set`, now correctly passed as a `str`)

✅ Tested via GitHub Actions with `pyzotero==1.6.11`  
✅ Syncs annotations from Zotero to Readwise without error  
✅ Captures failed items in `failed_zotero_items.json`

Let me know if you'd prefer a more granular exception structure or specific version pinning.