### PR TITLE
fix(release): Resolve semantic-release build failure and version detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,9 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v9.15.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
+        env:
+          # Ensure semantic-release can access uv in PATH
+          PATH: ${{ env.PATH }}
 
       - name: 🔍 Print Semantic Release Output
         if: always()
@@ -50,7 +53,10 @@ jobs:
 
       - name: 🛠️ Build distributions with uv
         if: steps.srelease.outputs.released == 'true'
-        run: uv build
+        run: |
+          echo "Building version ${{ steps.srelease.outputs.version }}"
+          uv build
+          ls -lh dist/
 
       - name: 🚀 Publish to PyPI
         if: steps.srelease.outputs.released == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,10 @@ version_toml = ["pyproject.toml:project.version"]
 version_variables = [
     "zotero2readwise/__init__.py:__version__",
 ]
-build_command = "uv build"
+# Don't build during semantic-release - we'll build afterwards when uv is available
+build_command = "echo 'Skipping build - will build after semantic-release'"
 major_on_zero = false
-tag_format = "{version}"
+tag_format = "v{version}"
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"
@@ -62,6 +63,22 @@ match = "(main|master)"
 [tool.semantic_release.changelog]
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = [
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "perf",
+    "test",
+    "build",
+    "ci",
+    "chore",
+]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
 
 [tool.semantic_release.remote]
 type = "github"


### PR DESCRIPTION
Fix two critical issues preventing successful releases:

## Issue 1: 'uv: command not found' during semantic-release **Root Cause:**
python-semantic-release action runs in its own Docker container which doesn't have access to uv installed in previous workflow steps.

**Solution:**
- Changed build_command from 'uv build' to an echo statement
- Semantic-release now only handles version bumping and tagging
- Actual package build happens AFTER semantic-release completes
- This way uv is available in the workflow environment for building

## Issue 2: Wrong version detection (0.1.0 instead of 1.3.0) **Root Cause:**
Tag format mismatch - existing tags use 'v' prefix (v1.2.0, v1.1.0) but semantic-release was configured for plain version (1.2.0).

**Solution:**
- Changed tag_format from '{version}' to 'v{version}'
- Now matches existing tag pattern in repository
- Semantic-release will correctly detect v1.2.0 as current version
- Next release will be v1.3.0 (for feat) or v1.2.1 (for fix)

## Additional Improvements:
- Added commit_parser_options for explicit version bump rules
- Enhanced build step to show version being built
- Added PATH environment to semantic-release step
- Better logging with 'ls -lh dist/' after build

These changes ensure semantic-release can:
1. Correctly detect the current version from tags
2. Calculate the next version based on commits
3. Skip the build step (which requires uv)
4. Let the workflow build the package after versioning is complete