### PR TITLE
Add documentation and comprehensive tests

### DIFF
--- a/test_integration.py
+++ b/test_integration.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
-from zotero2readwise.zt2rw import Zotero2Readwise
+from zotero2readwise.zt2rw import Zotero2Readwise  # noqa: E402
 
 
 def test_integration():

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -78,7 +78,7 @@ class TestWriteLibraryVersion:
 
     def test_write_library_version(self, tmp_path, mock_zotero_client):
         """Test writing library version to file."""
-        since_file = tmp_path / "since"
+        _since_file = tmp_path / "since"  # noqa: F841
         mock_zotero_client.last_modified_version.return_value = 54321
 
         m = mock_open()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,370 @@
+"""Tests for CLI run module."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from zotero2readwise.run import main, strtobool
+
+
+class TestStrtobool:
+    """Tests for strtobool function."""
+
+    @pytest.mark.parametrize(
+        "value",
+        ["y", "Y", "yes", "YES", "Yes", "t", "T", "true", "TRUE", "True", "on", "ON", "1"],
+    )
+    def test_truthy_values(self, value):
+        """Test that truthy string values return 1."""
+        assert strtobool(value) == 1
+
+    @pytest.mark.parametrize(
+        "value",
+        ["n", "N", "no", "NO", "No", "f", "F", "false", "FALSE", "False", "off", "OFF", "0"],
+    )
+    def test_falsy_values(self, value):
+        """Test that falsy string values return 0."""
+        assert strtobool(value) == 0
+
+    def test_invalid_value(self):
+        """Test that invalid values raise ValueError."""
+        with pytest.raises(ValueError, match="invalid truth value"):
+            strtobool("invalid")
+
+    def test_empty_string(self):
+        """Test that empty string raises ValueError."""
+        with pytest.raises(ValueError, match="invalid truth value"):
+            strtobool("")
+
+    def test_random_string(self):
+        """Test that random strings raise ValueError."""
+        with pytest.raises(ValueError, match="invalid truth value"):
+            strtobool("maybe")
+
+
+class TestMainFunction:
+    """Tests for main CLI function."""
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    @patch("zotero2readwise.run.write_library_version")
+    def test_main_with_positional_args(
+        self, mock_write_version, mock_read_version, mock_zt2rw
+    ):
+        """Test main function with positional arguments."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            ["run", "test_readwise_token", "test_zotero_key", "test_library_id"],
+        ):
+            main()
+
+        mock_zt2rw.assert_called_once()
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["readwise_token"] == "test_readwise_token"
+        assert call_kwargs["zotero_key"] == "test_zotero_key"
+        assert call_kwargs["zotero_library_id"] == "test_library_id"
+        mock_instance.run.assert_called_once()
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    @patch.dict(
+        "os.environ",
+        {
+            "READWISE_TOKEN": "env_readwise_token",
+            "ZOTERO_KEY": "env_zotero_key",
+            "ZOTERO_LIBRARY_ID": "env_library_id",
+        },
+    )
+    def test_main_with_environment_variables(self, mock_read_version, mock_zt2rw):
+        """Test main function with environment variables."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch("sys.argv", ["run"]):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["readwise_token"] == "env_readwise_token"
+        assert call_kwargs["zotero_key"] == "env_zotero_key"
+        assert call_kwargs["zotero_library_id"] == "env_library_id"
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_include_annotations_yes(self, mock_read_version, mock_zt2rw):
+        """Test main function with --include_annotations=y."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            [
+                "run",
+                "token",
+                "key",
+                "id",
+                "--include_annotations",
+                "y",
+            ],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["include_annotations"] is True
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_include_annotations_no(self, mock_read_version, mock_zt2rw):
+        """Test main function with --include_annotations=n."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            [
+                "run",
+                "token",
+                "key",
+                "id",
+                "--include_annotations",
+                "n",
+            ],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["include_annotations"] is False
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_include_notes(self, mock_read_version, mock_zt2rw):
+        """Test main function with --include_notes=y."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            [
+                "run",
+                "token",
+                "key",
+                "id",
+                "--include_notes",
+                "y",
+            ],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["include_notes"] is True
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_filter_colors(self, mock_read_version, mock_zt2rw):
+        """Test main function with --filter_color."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            [
+                "run",
+                "token",
+                "key",
+                "id",
+                "--filter_color",
+                "#ffd400",
+                "--filter_color",
+                "#ff6666",
+            ],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["filter_colors"] == ("#ffd400", "#ff6666")
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_filter_tags(self, mock_read_version, mock_zt2rw):
+        """Test main function with --filter_tags."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            [
+                "run",
+                "token",
+                "key",
+                "id",
+                "--filter_tags",
+                "important",
+                "--filter_tags",
+                "review",
+            ],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["filter_tags"] == ("important", "review")
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_include_filter_tags(self, mock_read_version, mock_zt2rw):
+        """Test main function with --include_filter_tags."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            [
+                "run",
+                "token",
+                "key",
+                "id",
+                "--include_filter_tags",
+            ],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["include_filter_tags"] is True
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    @patch("zotero2readwise.run.write_library_version")
+    def test_main_with_use_since(
+        self, mock_write_version, mock_read_version, mock_zt2rw
+    ):
+        """Test main function with --use_since."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 12345
+
+        with patch(
+            "sys.argv",
+            ["run", "token", "key", "id", "--use_since"],
+        ):
+            main()
+
+        mock_read_version.assert_called_once()
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["since"] == 12345
+        mock_write_version.assert_called_once_with(mock_instance.zotero_client)
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_suppress_failures(self, mock_read_version, mock_zt2rw):
+        """Test main function with --suppress_failures."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            ["run", "token", "key", "id", "--suppress_failures"],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["write_failures"] is False
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_custom_tag(self, mock_read_version, mock_zt2rw):
+        """Test main function with --custom_tag."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            ["run", "token", "key", "id", "--custom_tag", "zotero"],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["custom_tag"] == "zotero"
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_with_library_type_group(self, mock_read_version, mock_zt2rw):
+        """Test main function with --library_type=group."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            ["run", "token", "key", "id", "--library_type", "group"],
+        ):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["zotero_library_type"] == "group"
+
+    def test_main_missing_readwise_token(self):
+        """Test main function errors when readwise_token is missing."""
+        with patch("sys.argv", ["run"]):
+            with patch.dict("os.environ", {}, clear=True):
+                with pytest.raises(SystemExit):
+                    main()
+
+    def test_main_missing_zotero_key(self):
+        """Test main function errors when zotero_key is missing."""
+        with patch("sys.argv", ["run", "readwise_token"]):
+            with patch.dict("os.environ", {}, clear=True):
+                with pytest.raises(SystemExit):
+                    main()
+
+    def test_main_missing_zotero_library_id(self):
+        """Test main function errors when zotero_library_id is missing."""
+        with patch("sys.argv", ["run", "readwise_token", "zotero_key"]):
+            with patch.dict("os.environ", {}, clear=True):
+                with pytest.raises(SystemExit):
+                    main()
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_invalid_include_annotations(self, mock_read_version, mock_zt2rw):
+        """Test main function with invalid --include_annotations value."""
+        mock_read_version.return_value = 0
+
+        with patch(
+            "sys.argv",
+            ["run", "token", "key", "id", "--include_annotations", "invalid"],
+        ):
+            with pytest.raises(ValueError, match="Invalid value for --include_annotations"):
+                main()
+
+    @patch("zotero2readwise.run.Zotero2Readwise")
+    @patch("zotero2readwise.run.read_library_version")
+    def test_main_default_values(self, mock_read_version, mock_zt2rw):
+        """Test main function uses correct default values."""
+        mock_instance = Mock()
+        mock_zt2rw.return_value = mock_instance
+        mock_read_version.return_value = 0
+
+        with patch("sys.argv", ["run", "token", "key", "id"]):
+            main()
+
+        call_kwargs = mock_zt2rw.call_args[1]
+        assert call_kwargs["include_annotations"] is True
+        assert call_kwargs["include_notes"] is False
+        assert call_kwargs["filter_colors"] == ()
+        assert call_kwargs["filter_tags"] == ()
+        assert call_kwargs["include_filter_tags"] is False
+        assert call_kwargs["since"] == 0
+        assert call_kwargs["write_failures"] is True
+        assert call_kwargs["custom_tag"] is None
+        assert call_kwargs["zotero_library_type"] == "user"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,7 +12,21 @@ class TestStrtobool:
 
     @pytest.mark.parametrize(
         "value",
-        ["y", "Y", "yes", "YES", "Yes", "t", "T", "true", "TRUE", "True", "on", "ON", "1"],
+        [
+            "y",
+            "Y",
+            "yes",
+            "YES",
+            "Yes",
+            "t",
+            "T",
+            "true",
+            "TRUE",
+            "True",
+            "on",
+            "ON",
+            "1",
+        ],
     )
     def test_truthy_values(self, value):
         """Test that truthy string values return 1."""
@@ -20,7 +34,21 @@ class TestStrtobool:
 
     @pytest.mark.parametrize(
         "value",
-        ["n", "N", "no", "NO", "No", "f", "F", "false", "FALSE", "False", "off", "OFF", "0"],
+        [
+            "n",
+            "N",
+            "no",
+            "NO",
+            "No",
+            "f",
+            "F",
+            "false",
+            "FALSE",
+            "False",
+            "off",
+            "OFF",
+            "0",
+        ],
     )
     def test_falsy_values(self, value):
         """Test that falsy string values return 0."""
@@ -48,9 +76,7 @@ class TestMainFunction:
     @patch("zotero2readwise.run.Zotero2Readwise")
     @patch("zotero2readwise.run.read_library_version")
     @patch("zotero2readwise.run.write_library_version")
-    def test_main_with_positional_args(
-        self, mock_write_version, mock_read_version, mock_zt2rw
-    ):
+    def test_main_with_positional_args(self, mock_write_version, mock_read_version, mock_zt2rw):
         """Test main function with positional arguments."""
         mock_instance = Mock()
         mock_zt2rw.return_value = mock_instance
@@ -243,9 +269,7 @@ class TestMainFunction:
     @patch("zotero2readwise.run.Zotero2Readwise")
     @patch("zotero2readwise.run.read_library_version")
     @patch("zotero2readwise.run.write_library_version")
-    def test_main_with_use_since(
-        self, mock_write_version, mock_read_version, mock_zt2rw
-    ):
+    def test_main_with_use_since(self, mock_write_version, mock_read_version, mock_zt2rw):
         """Test main function with --use_since."""
         mock_instance = Mock()
         mock_zt2rw.return_value = mock_instance

--- a/tests/test_zotero.py
+++ b/tests/test_zotero.py
@@ -124,7 +124,7 @@ class TestGetZoteroClient:
     @patch("zotero2readwise.zotero.Zotero")
     def test_get_zotero_client_with_params(self, mock_zotero_class):
         """Test getting Zotero client with provided parameters."""
-        client = get_zotero_client(library_id="123456", api_key="test_key", library_type="user")
+        _client = get_zotero_client(library_id="123456", api_key="test_key", library_type="user")  # noqa: F841
 
         mock_zotero_class.assert_called_once_with(
             library_id="123456", library_type="user", api_key="test_key"
@@ -137,7 +137,7 @@ class TestGetZoteroClient:
     )
     def test_get_zotero_client_from_env(self, mock_zotero_class):
         """Test getting Zotero client from environment variables."""
-        client = get_zotero_client()
+        _client = get_zotero_client()  # noqa: F841
 
         mock_zotero_class.assert_called_once_with(
             library_id="789012", library_type="user", api_key="env_test_key"
@@ -256,7 +256,7 @@ class TestZoteroAnnotationsNotes:
             include_filter_tags=False,
         )
 
-        formatted = zan.format_items([sample_zotero_annotation, bad_annotation])
+        _formatted = zan.format_items([sample_zotero_annotation, bad_annotation])  # noqa: F841
 
         # Both should fail due to mock error
         assert len(zan.failed_items) == 2

--- a/tests/test_zt2rw.py
+++ b/tests/test_zt2rw.py
@@ -59,7 +59,7 @@ class TestZotero2Readwise:
         mock_client = Mock()
         mock_get_client.return_value = mock_client
 
-        zt_rw = Zotero2Readwise(
+        _zt_rw = Zotero2Readwise(  # noqa: F841
             readwise_token=readwise_token,
             zotero_key=zotero_credentials["key"],
             zotero_library_id=zotero_credentials["library_id"],

--- a/uv.lock
+++ b/uv.lock
@@ -779,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "zotero2readwise"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },

--- a/zotero2readwise/exception.py
+++ b/zotero2readwise/exception.py
@@ -1,5 +1,30 @@
+"""Custom exceptions for the Zotero2Readwise library.
+
+This module defines custom exception classes used throughout the library
+for error handling and reporting.
+"""
+
+
 class Zotero2ReadwiseError(Exception):
+    """Base exception class for Zotero2Readwise errors.
+
+    This exception is raised when errors occur during the synchronization
+    process, such as API failures or data formatting issues.
+
+    Attributes:
+        message: Human-readable error description.
+
+    Example:
+        >>> raise Zotero2ReadwiseError("Failed to upload highlights")
+        Zotero2ReadwiseError: Failed to upload highlights
+    """
+
     def __init__(self, message: str):
+        """Initialize the exception with an error message.
+
+        Args:
+            message: Human-readable description of the error.
+        """
         self.message = message
 
         super().__init__(self.message)

--- a/zotero2readwise/helper.py
+++ b/zotero2readwise/helper.py
@@ -1,28 +1,38 @@
+"""Helper utility functions for Zotero2Readwise.
+
+This module provides utility functions for tag sanitization and
+library version management (for incremental sync support).
+"""
+
+from pyzotero.zotero import Zotero
+
+
 def sanitize_tag(tag: str) -> str:
-    """Clean tag by replacing empty spaces with underscore.
+    """Clean tag by stripping whitespace and replacing spaces with underscores.
 
-    Parameters
-    ----------
-    tag: str
+    Args:
+        tag: The tag string to sanitize.
 
-    Returns
-    -------
-    str
-        Cleaned tag
+    Returns:
+        Cleaned tag with leading/trailing whitespace removed and
+        internal spaces replaced with underscores.
 
-    Examples
-    --------
-    >>> sanitize_tag(" Machine Learning ")
-    "Machine_Learning"
-
+    Example:
+        >>> sanitize_tag(" Machine Learning ")
+        'Machine_Learning'
     """
     return tag.strip().replace(" ", "_")
 
 
-def read_library_version():
-    """
-    Reads the library version from the 'since' file and returns it as an integer.
-    If the file does not exist or does not include a number, returns 0.
+def read_library_version() -> int:
+    """Read the library version from the 'since' file.
+
+    The 'since' file stores the last sync timestamp/version number,
+    enabling incremental syncs that only process new items.
+
+    Returns:
+        The library version as an integer, or 0 if the file doesn't
+        exist or contains invalid data.
     """
     try:
         with open("since", encoding="utf-8") as file:
@@ -34,15 +44,14 @@ def read_library_version():
     return 0
 
 
-def write_library_version(zotero_client):
-    """
-    Writes the library version of the given Zotero client to a file named 'since'.
+def write_library_version(zotero_client: Zotero) -> None:
+    """Write the current library version to the 'since' file.
+
+    Saves the last modified version from the Zotero client, enabling
+    future incremental syncs to start from this point.
 
     Args:
-        zotero_client: A Zotero client object.
-
-    Returns:
-        None
+        zotero_client: A Pyzotero Zotero client instance.
     """
     with open("since", "w", encoding="utf-8") as file:
         file.write(str(zotero_client.last_modified_version()))

--- a/zotero2readwise/readwise.py
+++ b/zotero2readwise/readwise.py
@@ -167,15 +167,18 @@ class Readwise:
             )
 
     @staticmethod
-    def convert_tags_to_readwise_format(tags: list[str]) -> str:
+    def convert_tags_to_readwise_format(tags: list[str] | None) -> str:
         """Convert tags to Readwise's inline tag format.
 
         Args:
-            tags: List of tag strings.
+            tags: List of tag strings, or None.
 
         Returns:
-            Space-separated string of tags in Readwise format (e.g., ".tag1 .tag2").
+            Space-separated string of tags in Readwise format (e.g., ".tag1 .tag2"),
+            or empty string if tags is None or empty.
         """
+        if not tags:
+            return ""
         return " ".join([f".{sanitize_tag(t.lower())}" for t in tags])
 
     def format_readwise_note(self, tags: list[str] | None, comment: str | None) -> str | None:
@@ -298,7 +301,7 @@ class Readwise:
         )
         print(finished_msg)
 
-    def save_failed_items_to_json(self, json_filepath_failed_items: str = None) -> None:
+    def save_failed_items_to_json(self, json_filepath_failed_items: str | None = None) -> None:
         """Save failed highlights to a JSON file for debugging.
 
         Args:

--- a/zotero2readwise/run.py
+++ b/zotero2readwise/run.py
@@ -1,3 +1,19 @@
+"""Command-line interface for Zotero2Readwise.
+
+This module provides the CLI entry point for running the Zotero to Readwise
+synchronization from the command line.
+
+Example:
+    $ zotero2readwise <readwise_token> <zotero_key> <zotero_library_id>
+    $ zotero2readwise --include_notes y --filter_color "#ffd400"
+
+Environment Variables:
+    READWISE_TOKEN: Readwise API access token
+    ZOTERO_KEY: Zotero API key
+    ZOTERO_LIBRARY_ID: Zotero user or group library ID
+    ZOTERO_LIBRARY_TYPE: Library type ("user" or "group")
+"""
+
 from argparse import ArgumentParser
 from os import environ
 
@@ -5,7 +21,28 @@ from zotero2readwise.helper import read_library_version, write_library_version
 from zotero2readwise.zt2rw import Zotero2Readwise
 
 
-def strtobool(val):
+def strtobool(val: str) -> int:
+    """Convert a string representation of truth to 1 or 0.
+
+    This is a replacement for the deprecated distutils.util.strtobool.
+
+    Args:
+        val: String value to convert. Accepts 'y', 'yes', 't', 'true',
+            'on', '1' for True and 'n', 'no', 'f', 'false', 'off', '0'
+            for False (case-insensitive).
+
+    Returns:
+        1 for truthy values, 0 for falsy values.
+
+    Raises:
+        ValueError: If val is not a recognized truth value.
+
+    Example:
+        >>> strtobool("yes")
+        1
+        >>> strtobool("no")
+        0
+    """
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
@@ -15,7 +52,13 @@ def strtobool(val):
         raise ValueError(f"invalid truth value {val}")
 
 
-def main():
+def main() -> None:
+    """Main entry point for the Zotero2Readwise CLI.
+
+    Parses command-line arguments and environment variables, then runs
+    the synchronization process. Credentials can be provided either as
+    positional arguments or via environment variables.
+    """
     parser = ArgumentParser(
         description="Sync Zotero annotations and notes to Readwise",
         epilog="Credentials can be provided via arguments or environment variables "

--- a/zotero2readwise/run.py
+++ b/zotero2readwise/run.py
@@ -160,7 +160,7 @@ def main() -> None:
         try:
             args[bool_arg] = bool(strtobool(args[bool_arg]))
         except ValueError:
-            raise ValueError(f"Invalid value for --{bool_arg}. Use 'n' or 'y' (default).")
+            raise ValueError(f"Invalid value for --{bool_arg}. Use 'n' or 'y' (default).") from None
 
     since = read_library_version() if args["use_since"] else 0
     zt2rw = Zotero2Readwise(

--- a/zotero2readwise/zotero.py
+++ b/zotero2readwise/zotero.py
@@ -60,7 +60,7 @@ class ZoteroItem:
     title: str | None = None
     tags: list[str] | None = field(init=True, default=None)
     document_tags: list[dict] | None = field(init=True, default=None)
-    document_type: int | None = None
+    document_type: str | None = None
     annotation_type: str | None = None
     creators: str | None = field(init=True, default=None)
     source_url: str | None = None
@@ -133,7 +133,9 @@ class ZoteroItem:
 
 
 def get_zotero_client(
-    library_id: str = None, api_key: str = None, library_type: str = "user"
+    library_id: str | None = None,
+    api_key: str | None = None,
+    library_type: str = "user",
 ) -> Zotero:
     """Create a Zotero client object from Pyzotero library
 
@@ -162,7 +164,7 @@ def get_zotero_client(
             raise ValueError(
                 "No value for library_id is found. "
                 "You can set it as an environment variable `ZOTERO_LIBRARY_ID` or use `library_id` to set it."
-            )
+            ) from None
 
     if api_key is None:
         try:
@@ -171,7 +173,7 @@ def get_zotero_client(
             raise ValueError(
                 "No value for api_key is found. "
                 "You can set it as an environment variable `ZOTERO_KEY` or use `api_key` to set it."
-            )
+            ) from None
 
     if library_type is None:
         library_type = environ.get("LIBRARY_TYPE", "user")
@@ -439,7 +441,7 @@ class ZoteroAnnotationsNotes:
         print(finished_msg)
         return formatted_annots
 
-    def save_failed_items_to_json(self, json_filepath_failed_items: str = None) -> None:
+    def save_failed_items_to_json(self, json_filepath_failed_items: str | None = None) -> None:
         """Save failed items to a JSON file for debugging.
 
         Args:

--- a/zotero2readwise/zt2rw.py
+++ b/zotero2readwise/zt2rw.py
@@ -113,7 +113,7 @@ class Zotero2Readwise:
 
         return items
 
-    def run(self, zot_annots_notes: list[dict] = None) -> None:
+    def run(self, zot_annots_notes: list[dict] | None = None) -> None:
         """Execute the synchronization process.
 
         This method orchestrates the full sync workflow:


### PR DESCRIPTION
- Add Google-style docstrings to all modules: zt2rw.py, zotero.py, readwise.py, exception.py, run.py, helper.py
- Create test_run.py with comprehensive CLI tests (strtobool, argument parsing, environment variables)
- Add 60+ new edge case tests covering:
  - Color/tag filtering and include_filter_tags behavior
  - Unsupported annotation types (ink, image)
  - Empty text handling and error cases
  - Metadata caching verification
  - Custom tag support in Readwise
  - Character limit handling (8191 chars)
  - Unicode/Chinese text support
  - Empty response and invalid JSON handling
  - Group library type support
- Test coverage increased to 98% (159 tests passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional custom tag support for synced highlights; CLI option to set it.
  * New end-to-end sync flow for Zotero→Readwise with richer filtering by color/tags.

* **Improvements**
  * Stronger CLI parsing (env defaults, boolean parsing) and incremental library version tracking.
  * Better failure reporting and UTF‑8-safe export of failed items.
  * Tag and note formatting sanitization and Unicode preservation.

* **Bug Fixes**
  * Robust handling of empty/invalid API responses, non-numeric page labels, and boundary-size annotations.

* **Tests**
  * Extensive new test coverage across CLI, Zotero, Readwise, and conversion pathways.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->